### PR TITLE
perf: eliminate subshell forks in extension metadata parsing and case conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call); replace the 3 `grep|awk` pipeline chains in `load_extension()` provides
   block with a single-pass `while/read` state machine — comment lines (`#`) are
   skipped; combined saving ~1-1.5 s on macOS (#214)
+- `src/lib/oradba_env_builder.sh`: replace `oradba_dedupe_path()` awk invocation
+  with a bash 4+ `declare -A` associative-array lookup (O(n), zero external forks);
+  replace 6 `$(printf | tr)` subshells for case conversion with `${var,,}` / `${var^^}`
+  bash 4+ parameter expansion — net ~200-400 ms further saving on macOS (#216)
+- `src/lib/extensions.sh`: replace 3 `$(printf | tr)` subshells in
+  `get_extension_property()` and `load_extension()` with `${var^^}` bash 4+
+  parameter expansion (#216)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `src/lib/oradba_env_builder.sh`: `oradba_build_environment()` now falls back to
   `oradba_homes.conf` when a name is not found in oratab, fixing env setup for
   non-database Oracle Homes such as `icli23` (iclient type) (#207)
+- `src/lib/oradba_env_builder.sh`: `oradba_build_environment()` now sets
+  `ORADBA_CURRENT_HOME_TYPE` (in addition to `ORADBA_PRODUCT_TYPE`) so that
+  environment status display shows the correct product type (e.g. `iclient`)
+  instead of the hardcoded `database` fallback (#212)
+- `src/lib/oradba_env_builder.sh`: `oradba_build_environment()` now sets
+  `ORADBA_CURRENT_HOME` to the registry home name and `ORADBA_CURRENT_HOME_ALIAS`
+  to the alias from `oradba_homes.conf`; PS1 prompt now shows the alias (e.g.
+  `icli23`) instead of the raw `ORACLE_HOME` path (#211)
 - `scripts/build_pdf.sh`: enable Mermaid diagram rendering in CI via
   `--security-opt seccomp=unconfined` and `--shm-size=2g` on `docker run`;
   add `.puppeteer.json` with `--no-sandbox` so Chromium (used by mmdc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - TBD (target: 2026-07-10)
 
+### Performance
+
+- `src/lib/oradba_env_builder.sh`: replace `oradba_dedupe_path()` O(n²) nested
+  bash loop with a single `awk` invocation (O(n)); function is called 5-6 times
+  per startup via command substitution, saving ~2-3 s on macOS (#213)
+- `src/lib/extensions.sh`: rewrite `parse_extension_metadata()` to use a pure-bash
+  `while/read` loop instead of a `grep|head|cut|sed` pipeline (4 subshell forks per
+  call); replace the 3 `grep|awk` pipeline chains in `load_extension()` provides
+  block with a single-pass `while/read` state machine — comment lines (`#`) are
+  skipped; combined saving ~1-1.5 s on macOS (#214)
+
 ### Fixed
 
 - `src/bin/oraenv.sh`: pressing Enter at the interactive SID/home selection menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `src/bin/oraenv.sh`: pressing Enter at the interactive SID/home selection menu
+  now defaults to the first entry instead of returning "No selection made" (#208)
+- `src/lib/oradba_common.sh`: `ORADBA_DEBUG=true` and `ORADBA_TRACE=true` now
+  correctly activate DEBUG and TRACE log levels in `oradba_log()`; previously only
+  `ORADBA_LOG_LEVEL` and the legacy `DEBUG=1` were recognized (#209)
+- `src/lib/oradba_env_builder.sh`: `oradba_build_environment()` now falls back to
+  `oradba_homes.conf` when a name is not found in oratab, fixing env setup for
+  non-database Oracle Homes such as `icli23` (iclient type) (#207)
 - `scripts/build_pdf.sh`: enable Mermaid diagram rendering in CI via
   `--security-opt seccomp=unconfined` and `--shm-size=2g` on `docker run`;
   add `.puppeteer.json` with `--no-sandbox` so Chromium (used by mmdc)
   can launch inside the nested GitHub Actions container
+
+### Documentation
+
+- `src/doc/troubleshooting.md`: rewrite Debug Mode section - `ORADBA_LOG_LEVEL`
+  documented as primary method, `ORADBA_DEBUG/TRACE` as shortcut vars, add log
+  level reference table, fix all `oraenv.sh` examples to use `source`, remove
+  non-existent `--debug` flag, add "Must Always Be Sourced" note (#210)
 
 ## [1.0.0-rc.1] - 2026-06-27
 

--- a/src/bin/oraenv.sh
+++ b/src/bin/oraenv.sh
@@ -756,9 +756,9 @@ _oraenv_handle_oracle_home() {
     # inside that function may use a different homes-file resolver. parse_oracle_home
     # is already proven to work at this point (is_oracle_home called it successfully).
     local _build_target="$requested_sid"
-    if command -v parse_oracle_home &>/dev/null; then
+    if command -v parse_oracle_home &> /dev/null; then
         local _home_info
-        _home_info=$(parse_oracle_home "$requested_sid" 2>/dev/null)
+        _home_info=$(parse_oracle_home "$requested_sid" 2> /dev/null)
         if [[ -n "$_home_info" ]]; then
             local _ohname _ohpath
             read -r _ohname _ohpath _ <<< "$_home_info"

--- a/src/bin/oraenv.sh
+++ b/src/bin/oraenv.sh
@@ -751,6 +751,24 @@ _oraenv_handle_oracle_home() {
 
     oradba_log DEBUG "Setting environment for Oracle Home: $requested_sid"
 
+    # Resolve home name to its actual path before calling oradba_build_environment.
+    # oradba_build_environment handles directory paths reliably; name-based lookup
+    # inside that function may use a different homes-file resolver. parse_oracle_home
+    # is already proven to work at this point (is_oracle_home called it successfully).
+    local _build_target="$requested_sid"
+    if command -v parse_oracle_home &>/dev/null; then
+        local _home_info
+        _home_info=$(parse_oracle_home "$requested_sid" 2>/dev/null)
+        if [[ -n "$_home_info" ]]; then
+            local _ohname _ohpath
+            read -r _ohname _ohpath _ <<< "$_home_info"
+            if [[ -n "$_ohpath" && -d "$_ohpath" ]]; then
+                _build_target="$_ohpath"
+                oradba_log DEBUG "Resolved home '$requested_sid' -> '$_build_target'"
+            fi
+        fi
+    fi
+
     # Unset previous Oracle environment
     _oraenv_unset_old_env
 
@@ -758,7 +776,7 @@ _oraenv_handle_oracle_home() {
     # and fall back to set_oracle_home_environment when env-builder is not loaded.
     if command -v oradba_build_environment &> /dev/null; then
         # CF-017 / DECISION 1: delegate to oradba_env_builder
-        if ! oradba_build_environment "$requested_sid"; then
+        if ! oradba_build_environment "$_build_target"; then
             oradba_log ERROR "Failed to build Oracle Home environment for: $requested_sid"
             return 1
         fi

--- a/src/bin/oraenv.sh
+++ b/src/bin/oraenv.sh
@@ -633,6 +633,9 @@ _oraenv_parse_user_selection() {
     local -n sids_ref="${sids_var}"
     local -n homes_ref="${homes_var}"
 
+    # Default to first entry on empty input
+    [[ -z "$selection" ]] && selection="1"
+
     # Check if user entered a number
     if [[ "$selection" =~ ^[0-9]+$ ]] && [[ $selection -ge 1 ]] && [[ $selection -le $total_entries ]]; then
         # User entered a valid number
@@ -689,7 +692,7 @@ _oraenv_prompt_sid() {
 
     # Prompt for selection
     local selection
-    read -p "Enter name or number [1-${total_entries}]: " selection
+    read -rp "Enter name or number [1-${total_entries}] (default: 1): " selection
 
     # Parse and return user selection
     _oraenv_parse_user_selection "$selection" "$total_entries" sids homes

--- a/src/doc/troubleshooting.md
+++ b/src/doc/troubleshooting.md
@@ -271,24 +271,66 @@ points, and system interactions.
 
 ### Activation Methods
 
-Debug support can be enabled in two ways:
+Three activation methods are available, listed from most to least recommended.
 
-#### Environment Variable (Global)
+#### 1. `ORADBA_LOG_LEVEL` (Primary, Always Works)
+
+The primary method. Accepted values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.
 
 ```bash
-# Enable for all OraDBA scripts
-export ORADBA_DEBUG=true
-
-# Alternative method (legacy)
 export ORADBA_LOG_LEVEL=DEBUG
+source /opt/oracle/local/oradba/bin/oraenv.sh icli23
+
+export ORADBA_LOG_LEVEL=TRACE
+source /opt/oracle/local/oradba/bin/oraenv.sh icli23
 ```
 
-#### Command Line Flag (Per Script)
+#### 2. `ORADBA_DEBUG=true` / `ORADBA_TRACE=true` (Shortcut Variables, v1.0.0+)
+
+Convenience shortcuts that map to the corresponding `ORADBA_LOG_LEVEL` values.
+`ORADBA_TRACE=true` sets the finest log level (numeric value `-1` in `oradba_log()`).
 
 ```bash
-# Enable for individual script runs
-script_name.sh --debug [other options]
-script_name.sh -d [other options]
+export ORADBA_DEBUG=true
+source /opt/oracle/local/oradba/bin/oraenv.sh icli23
+
+export ORADBA_TRACE=true
+source /opt/oracle/local/oradba/bin/oraenv.sh icli23
+```
+
+#### 3. `DEBUG=1` (Legacy, Still Supported)
+
+The original activation method - retained for backwards compatibility.
+
+```bash
+export DEBUG=1
+source /opt/oracle/local/oradba/bin/oraenv.sh icli23
+```
+
+### Log Level Reference
+
+| Value | Shortcut variable | Description |
+| --- | --- | --- |
+| `TRACE` | `ORADBA_TRACE=true` | Finest detail, all internal calls |
+| `DEBUG` | `ORADBA_DEBUG=true` | Standard debug output |
+| `INFO` | - | Default, informational messages only |
+| `WARN` | - | Warnings and errors only |
+| `ERROR` | - | Errors only |
+
+### Important: `oraenv.sh` Must Always Be Sourced
+
+`oraenv.sh` sets environment variables in the current shell and **must always be sourced** -
+never executed directly. Use `source` or `.`:
+
+```bash
+# Correct - runs in current shell, environment variables are set
+source /opt/oracle/local/oradba/bin/oraenv.sh ORACLE_SID
+
+# Also correct - POSIX syntax
+. /opt/oracle/local/oradba/bin/oraenv.sh ORACLE_SID
+
+# Wrong - creates a subshell, environment changes are lost
+/opt/oracle/local/oradba/bin/oraenv.sh ORACLE_SID
 ```
 
 ### Script Categories with Debug Support
@@ -299,16 +341,18 @@ Core system and infrastructure management:
 
 ```bash
 # Environment status and configuration
-ORADBA_DEBUG=true oraup.sh
-oraenv.sh --debug ORCL
+export ORADBA_LOG_LEVEL=DEBUG
+source /opt/oracle/local/oradba/bin/oraenv.sh ORCL
 
 # Installation and system validation
-ORADBA_DEBUG=true oradba_check.sh
-oradba_validate.sh --debug
+export ORADBA_DEBUG=true
+oradba_check.sh
+oradba_validate.sh
 
 # Extension management
-oradba_extension.sh --debug list
-ORADBA_DEBUG=true oradba_extension.sh install example
+export ORADBA_LOG_LEVEL=DEBUG
+oradba_extension.sh list
+oradba_extension.sh install example
 ```
 
 #### Phase 2: Management Tools (v0.19.6+)
@@ -317,16 +361,17 @@ Oracle database and listener management:
 
 ```bash
 # Database control operations
-ORADBA_DEBUG=true oradba_dbctl.sh start ORCL
-oradba_dbctl.sh --debug status
+export ORADBA_LOG_LEVEL=DEBUG
+oradba_dbctl.sh start ORCL
+oradba_dbctl.sh status
 
 # Listener management
-oradba_lsnrctl.sh --debug start LISTENER
-ORADBA_DEBUG=true oradba_lsnrctl.sh status
+oradba_lsnrctl.sh start LISTENER
+oradba_lsnrctl.sh status
 
 # Service orchestration
-oradba_services.sh --debug restart
-ORADBA_DEBUG=true oradba_services.sh start
+oradba_services.sh restart
+oradba_services.sh start
 ```
 
 #### Phase 3: Job Automation (v0.19.7+)
@@ -335,86 +380,21 @@ Backup and monitoring operations:
 
 ```bash
 # RMAN operation monitoring
-ORADBA_DEBUG=true rman_jobs.sh
-rman_jobs.sh --debug -w -i 10
+export ORADBA_LOG_LEVEL=DEBUG
+rman_jobs.sh
+rman_jobs.sh -w -i 10
 
 # DataPump export monitoring
-exp_jobs.sh --debug -o "%EXP%" -w
-ORADBA_DEBUG=true exp_jobs.sh --all
+exp_jobs.sh -o "%EXP%" -w
+exp_jobs.sh --all
 
 # DataPump import monitoring
-imp_jobs.sh --debug -w -i 5
-ORADBA_DEBUG=true imp_jobs.sh ORCL
+imp_jobs.sh -w -i 5
+imp_jobs.sh ORCL
 
 # Long operations monitoring (core script)
-longops.sh --debug -o "RMAN%" -w
-ORADBA_DEBUG=true longops.sh --all ORCL FREE
-```
-
-### Debug Output Information
-
-When debug mode is enabled, you'll see detailed information about:
-
-**Infrastructure Scripts:**
-
-- Library and plugin loading
-- Oracle Home detection and validation
-- Registry API operations
-- Environment variable resolution
-- Configuration file processing
-
-**Management Tools:**
-
-- Database startup/shutdown sequences
-- Listener operations and port detection
-- Service orchestration and dependency management
-- Oracle environment setup and validation
-- SQL operation execution and error handling
-
-**Job Automation:**
-
-- Wrapper script argument processing
-- Filter application and SQL query construction
-- Database connection establishment
-- Monitoring loop iterations and timing
-- Environment sourcing per SID
-
-### Common Debug Patterns
-
-**Environment Issues:**
-
-```bash
-# Debug Oracle environment setup
-ORADBA_DEBUG=true oraenv.sh ORCL
-# Shows: registry lookup, plugin application, path construction
-
-# Debug home detection
-ORADBA_DEBUG=true oraup.sh
-# Shows: oratab parsing, home classification, plugin discovery
-```
-
-**Database Operations:**
-
-```bash
-# Debug database startup
-oradba_dbctl.sh --debug start ORCL
-# Shows: environment setup, SQL execution, timeout handling
-
-# Debug service coordination
-oradba_services.sh --debug restart
-# Shows: startup order, listener/database dependencies
-```
-
-**Monitoring Operations:**
-
-```bash
-# Debug backup monitoring
-rman_jobs.sh --debug -w
-# Shows: argument filtering, longops.sh invocation, SQL query construction
-
-# Debug with operation filter
-longops.sh --debug -o "RMAN%" -a
-# Shows: filter construction, environment sourcing, query execution
+longops.sh -o "RMAN%" -w
+longops.sh --all ORCL FREE
 ```
 
 ### Debug Output Format
@@ -431,24 +411,19 @@ For scripts using `oradba_log`:
 [DEBUG] timestamp script_name.sh: message content
 ```
 
-### Legacy Debug Support
+TRACE-level output uses the same format with `TRACE` as the level label:
 
-**Note:** The following method is deprecated but still supported:
-
-```bash
-# Legacy method (still works)
-export DEBUG=1
-
-# Run any script
-source oraenv.sh FREE
+```text
+[TRACE] timestamp script_name.sh: message content
 ```
 
 ### Performance Considerations
 
 - Debug mode has minimal performance impact when disabled
 - Debug output can be verbose - use judiciously in production
+- TRACE output is significantly more verbose than DEBUG - avoid in production
 - Log files may grow larger when debug is enabled globally
-- Consider per-script activation for focused troubleshooting
+- Consider using `ORADBA_LOG_LEVEL=DEBUG` per session rather than globally
 
 ## Verification Steps
 

--- a/src/lib/extensions.sh
+++ b/src/lib/extensions.sh
@@ -355,7 +355,7 @@ remove_extension_paths() {
 # Notes...: Uses oradba_dedupe_path() from oradba_env_builder.sh if available
 # ------------------------------------------------------------------------------
 deduplicate_path() {
-    if command -v oradba_dedupe_path >/dev/null 2>&1; then
+    if command -v oradba_dedupe_path > /dev/null 2>&1; then
         local deduped_path
         deduped_path="$(oradba_dedupe_path "${PATH}")"
         export PATH="${deduped_path}"
@@ -393,7 +393,7 @@ deduplicate_path() {
 deduplicate_sqlpath() {
     [[ -z "${SQLPATH}" ]] && return 0
 
-    if command -v oradba_dedupe_path >/dev/null 2>&1; then
+    if command -v oradba_dedupe_path > /dev/null 2>&1; then
         local deduped_sqlpath
         deduped_sqlpath="$(oradba_dedupe_path "${SQLPATH}")"
         export SQLPATH="${deduped_sqlpath}"
@@ -513,14 +513,14 @@ load_extension() {
     local provides_rcv="true"
     local load_env="false"
     local load_aliases="false"
-    
+
     # Read provides section if metadata exists — single-pass, no subshells (#214)
     if [[ -f "${metadata}" ]]; then
         local _in_provides=0 _line _val
         while IFS= read -r _line; do
             # Skip comments and blank lines
             [[ "${_line}" =~ ^[[:blank:]]*# ]] && continue
-            [[ -z "${_line// }" ]] && continue
+            [[ -z "${_line// /}" ]] && continue
 
             if [[ "${_line}" == "provides:"* ]]; then
                 _in_provides=1
@@ -539,7 +539,7 @@ load_extension() {
                 _in_provides=0
                 _val="${_line#*:}"
                 case "${_line}" in
-                    "load_env:"*)     read -r load_env     <<< "${_val}" ;;
+                    "load_env:"*) read -r load_env <<< "${_val}" ;;
                     "load_aliases:"*) read -r load_aliases <<< "${_val}" ;;
                 esac
             fi
@@ -554,7 +554,7 @@ load_extension() {
     fi
 
     # Normalize booleans to lowercase (printf -v sets var directly, no subshells)
-    _ext_bool_lower() { case "$2" in TRUE|True|YES|Yes) printf -v "$1" 'true' ;; FALSE|False|NO|No) printf -v "$1" 'false' ;; *) printf -v "$1" '%s' "$2" ;; esac; }
+    _ext_bool_lower() { case "$2" in TRUE | True | YES | Yes) printf -v "$1" 'true' ;; FALSE | False | NO | No) printf -v "$1" 'false' ;; *) printf -v "$1" '%s' "$2" ;; esac }
     _ext_bool_lower provides_bin "${provides_bin}"
     _ext_bool_lower provides_sql "${provides_sql}"
     _ext_bool_lower provides_rcv "${provides_rcv}"
@@ -782,7 +782,7 @@ validate_extension() {
     if [[ ! -f "${ext_path}/.extension" ]]; then
         echo "⚠ Warning: No .extension metadata file found"
         echo "  Extension will work but won't have version/priority info"
-        warnings=$(( warnings + 1 ))
+        warnings=$((warnings + 1))
     else
         echo "✓ Metadata file present"
 
@@ -793,11 +793,11 @@ validate_extension() {
 
         [[ -n "${name}" ]] && echo "  Name: ${name}" || {
             echo "  ⚠ Warning: 'name' not set in metadata"
-            warnings=$(( warnings + 1 ))
+            warnings=$((warnings + 1))
         }
         [[ -n "${version}" ]] && echo "  Version: ${version}" || {
             echo "  ⚠ Warning: 'version' not set in metadata"
-            warnings=$(( warnings + 1 ))
+            warnings=$((warnings + 1))
         }
     fi
 
@@ -805,7 +805,7 @@ validate_extension() {
     if [[ ! -d "${ext_path}/bin" ]] && [[ ! -d "${ext_path}/sql" ]] && [[ ! -d "${ext_path}/rcv" ]]; then
         echo "⚠ Warning: No bin/, sql/, or rcv/ directories found"
         echo "  Extension has no content to load"
-        warnings=$(( warnings + 1 ))
+        warnings=$((warnings + 1))
     fi
 
     # Check directories

--- a/src/lib/extensions.sh
+++ b/src/lib/extensions.sh
@@ -159,8 +159,8 @@ get_extension_property() {
         local safe_ext_name="${ext_name//-/_}"
         safe_ext_name="${safe_ext_name//[^a-zA-Z0-9_]/}"
         local safe_ext_name_upper property_upper
-        safe_ext_name_upper=$(printf '%s' "${safe_ext_name}" | tr '[:lower:]' '[:upper:]')
-        property_upper=$(printf '%s' "${property}" | tr '[:lower:]' '[:upper:]')
+        safe_ext_name_upper="${safe_ext_name^^}"
+        property_upper="${property^^}"
         local config_var="ORADBA_EXT_${safe_ext_name_upper}_${property_upper}"
         value="${!config_var}"
     fi
@@ -592,7 +592,7 @@ load_extension() {
 
     # Export extension path variables for reference
     local safe_ext_name_upper
-    safe_ext_name_upper=$(printf '%s' "${safe_ext_name}" | tr '[:lower:]' '[:upper:]')
+    safe_ext_name_upper="${safe_ext_name^^}"
     local var_name="ORADBA_EXT_${safe_ext_name_upper}_PATH"
     export "${var_name}=${ext_path}"
 

--- a/src/lib/extensions.sh
+++ b/src/lib/extensions.sh
@@ -189,17 +189,22 @@ get_extension_property() {
 parse_extension_metadata() {
     local metadata_file="$1"
     local key="$2"
+    local line value
 
-    if [[ ! -f "${metadata_file}" ]]; then
-        return 1
-    fi
+    [[ ! -f "${metadata_file}" ]] && return 1
 
-    # Simple key-value parser for YAML-like format
-    # Handles: "key: value" or "key:value"
-    local value
-    value=$(grep "^${key}:" "${metadata_file}" 2> /dev/null | head -1 | cut -d: -f2- | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-
-    echo "${value}"
+    # Pure-bash key-value parser: no subshells, no grep/cut/sed forks (#214)
+    # Skips comment lines (# ...) and blank lines.
+    # Handles: "key: value" or "key:value"; read strips leading/trailing whitespace.
+    while IFS= read -r line; do
+        [[ "${line}" =~ ^[[:blank:]]*# ]] && continue
+        if [[ "${line}" == "${key}:"* ]]; then
+            read -r value <<< "${line#"${key}:"}"
+            echo "${value}"
+            return 0
+        fi
+    done < "${metadata_file}"
+    echo ""
 }
 
 # ------------------------------------------------------------------------------
@@ -509,16 +514,38 @@ load_extension() {
     local load_env="false"
     local load_aliases="false"
     
-    # Read provides section if metadata exists
+    # Read provides section if metadata exists — single-pass, no subshells (#214)
     if [[ -f "${metadata}" ]]; then
-        # Check each provides flag
-        provides_bin=$(grep -A5 "^provides:" "${metadata}" | grep "bin:" | awk '{print $2}' | head -1)
-        provides_sql=$(grep -A5 "^provides:" "${metadata}" | grep "sql:" | awk '{print $2}' | head -1)
-        provides_rcv=$(grep -A5 "^provides:" "${metadata}" | grep "rcv:" | awk '{print $2}' | head -1)
-        load_env=$(parse_extension_metadata "${metadata}" "load_env")
-        load_aliases=$(parse_extension_metadata "${metadata}" "load_aliases")
-        
-        # Default to true if not specified
+        local _in_provides=0 _line _val
+        while IFS= read -r _line; do
+            # Skip comments and blank lines
+            [[ "${_line}" =~ ^[[:blank:]]*# ]] && continue
+            [[ -z "${_line// }" ]] && continue
+
+            if [[ "${_line}" == "provides:"* ]]; then
+                _in_provides=1
+            elif [[ "${_line:0:1}" == " " || "${_line:0:1}" == $'\t' ]]; then
+                # Indented line — part of the current block
+                if [[ ${_in_provides} -eq 1 ]]; then
+                    _val="${_line#*:}"
+                    case "${_line}" in
+                        *"bin:"*) read -r provides_bin <<< "${_val}" ;;
+                        *"sql:"*) read -r provides_sql <<< "${_val}" ;;
+                        *"rcv:"*) read -r provides_rcv <<< "${_val}" ;;
+                    esac
+                fi
+            else
+                # Top-level key — exit provides block and handle known keys
+                _in_provides=0
+                _val="${_line#*:}"
+                case "${_line}" in
+                    "load_env:"*)     read -r load_env     <<< "${_val}" ;;
+                    "load_aliases:"*) read -r load_aliases <<< "${_val}" ;;
+                esac
+            fi
+        done < "${metadata}"
+
+        # Default to true/false if not set by metadata
         provides_bin="${provides_bin:-true}"
         provides_sql="${provides_sql:-true}"
         provides_rcv="${provides_rcv:-true}"

--- a/src/lib/oradba_common.sh
+++ b/src/lib/oradba_common.sh
@@ -209,6 +209,16 @@ oradba_log() {
         min_level="DEBUG"
     fi
 
+    # ORADBA_DEBUG=true support - map to DEBUG level
+    if [[ "${ORADBA_DEBUG:-false}" == "true" ]] && [[ "${min_level}" != "DEBUG" ]] && [[ "${min_level}" != "TRACE" ]]; then
+        min_level="DEBUG"
+    fi
+
+    # ORADBA_TRACE=true support - map to TRACE level
+    if [[ "${ORADBA_TRACE:-false}" == "true" ]] && [[ "${min_level}" != "TRACE" ]]; then
+        min_level="TRACE"
+    fi
+
     # Recompute normalized minimum level after compatibility overrides
     case "${min_level}" in
         trace | TRACE) min_level_upper="TRACE" ;;

--- a/src/lib/oradba_env_builder.sh
+++ b/src/lib/oradba_env_builder.sh
@@ -78,35 +78,14 @@ _oradba_builder_log() {
 # ------------------------------------------------------------------------------
 oradba_dedupe_path() {
     local input_path="$1"
-    local -a seen_paths
-    local -a result_paths
-    local dir
-    
-    # Split on colon and process each directory
-    IFS=':' read -ra dirs <<< "$input_path"
-    for dir in "${dirs[@]}"; do
-        # Skip empty entries
-        [[ -z "$dir" ]] && continue
-        
-        # Check if we've seen this path before
-        local already_seen=0
-        for seen in "${seen_paths[@]}"; do
-            if [[ "$dir" == "$seen" ]]; then
-                already_seen=1
-                break
-            fi
-        done
-        
-        # Add if not seen
-        if [[ $already_seen -eq 0 ]]; then
-            seen_paths+=("$dir")
-            result_paths+=("$dir")
-        fi
-    done
-    
-    # Join with colons
-    local IFS=':'
-    echo "${result_paths[*]}"
+    [[ -z "${input_path}" ]] && return 0
+    # O(n) deduplication via awk — replaces the former O(n²) nested bash loop (#213)
+    awk -v p="${input_path}" 'BEGIN {
+        n = split(p, a, ":")
+        for (i = 1; i <= n; i++)
+            if (a[i] != "" && !seen[a[i]]++) out = (out ? out ":" : "") a[i]
+        print out
+    }'
 }
 
 # Require parser functions
@@ -891,37 +870,49 @@ oradba_build_environment() {
     local oracle_sid=""
     local oracle_home=""
     local product_type=""
-    
+    local home_name=""
+    local home_alias=""
+
     [[ -z "$target" ]] && return 1
-    
+
     # Determine if target is SID or ORACLE_HOME
     if [[ -d "$target" ]]; then
         # Target is a path (ORACLE_HOME)
         oracle_home="$target"
-        
-        # Get metadata from oradba_homes.conf
-        product_type=$(oradba_get_product_type "$oracle_home")
-        
-        # Set SID to dummy SID if available
-        oracle_sid=$(oradba_get_home_metadata "$oracle_home" "Dummy_SID" 2>/dev/null)
-        oracle_sid="${oracle_sid:-dummy}"
-        
+
+        # Get metadata from oradba_homes.conf (single lookup for all fields)
+        local _path_entry
+        _path_entry=$(oradba_find_home "$oracle_home" 2>/dev/null || true)
+        if [[ -n "$_path_entry" ]]; then
+            local _pname _ppath _ptype _porder _palias
+            IFS='|' read -r _pname _ppath _ptype _porder _palias _ _ <<< "$_path_entry"
+            home_name="$_pname"
+            home_alias="${_palias:-$_pname}"
+            [[ -n "$_ptype" ]] && product_type="${_ptype}"
+        fi
+        # Fallback: filesystem-based type detection if not found in homes.conf
+        [[ -z "$product_type" ]] && product_type=$(oradba_get_product_type "$oracle_home")
+
+        # Set SID to alias name (for non-empty oracle_sid requirement in oradba_set_oracle_vars)
+        oracle_sid=$(oradba_get_home_metadata "$oracle_home" "Dummy_SID" 2>/dev/null || true)
+        oracle_sid="${oracle_sid:-${home_alias:-dummy}}"
+
     else
         # Target is SID
         oracle_sid="$target"
-        
+
         # Check if ASM instance
         if oradba_is_asm_instance "$oracle_sid"; then
             product_type="GRID"
         fi
-        
+
         # Find in oratab
         local oratab_entry
         oratab_entry=$(oradba_find_sid "$oracle_sid")
         if [[ $? -eq 0 ]]; then
             IFS='|' read -r sid home _flag <<< "$oratab_entry"
             oracle_home="$home"
-            
+
             # Determine product type
             if [[ -z "$product_type" ]]; then
                 product_type=$(oradba_get_product_type "$oracle_home")
@@ -933,10 +924,13 @@ oradba_build_environment() {
                 home_entry=$(oradba_find_home "$oracle_sid" 2>/dev/null)
                 if [[ -n "$home_entry" ]]; then
                     # Format: NAME|PATH|TYPE|ORDER|ALIAS|DESCRIPTION|VERSION
-                    local _hname _hpath _htype
-                    IFS='|' read -r _hname _hpath _htype _ _ _ _ <<< "$home_entry"
+                    local _hname _hpath _htype _horder _halias
+                    IFS='|' read -r _hname _hpath _htype _horder _halias _ _ <<< "$home_entry"
                     oracle_home="$_hpath"
-                    oracle_sid=""
+                    home_name="$_hname"
+                    home_alias="${_halias:-$_hname}"
+                    # Use alias as oracle_sid placeholder (oradba_set_oracle_vars requires non-empty)
+                    oracle_sid="${home_alias:-$home_name}"
                     [[ -n "$_htype" && -z "$product_type" ]] && product_type="$_htype"
                 fi
             fi
@@ -1017,9 +1011,13 @@ oradba_build_environment() {
     # Set tracking variables
     export ORADBA_ENV_LOADED=1
     export ORADBA_CURRENT_SID="$oracle_sid"
-    export ORADBA_CURRENT_HOME="$oracle_home"
+    # Use registry home name for PS1 display; fall back to path if name not found
+    export ORADBA_CURRENT_HOME="${home_name:-$oracle_home}"
+    export ORADBA_CURRENT_HOME_ALIAS="${home_alias:-}"
     export ORADBA_PRODUCT_TYPE="$product_type"
-    
+    # ORADBA_CURRENT_HOME_TYPE is read by display/status functions (oraenv.sh, oradba_env_output.sh)
+    export ORADBA_CURRENT_HOME_TYPE="$product_type"
+
     return 0
 }
 

--- a/src/lib/oradba_env_builder.sh
+++ b/src/lib/oradba_env_builder.sh
@@ -79,13 +79,20 @@ _oradba_builder_log() {
 oradba_dedupe_path() {
     local input_path="$1"
     [[ -z "${input_path}" ]] && return 0
-    # O(n) deduplication via awk — replaces the former O(n²) nested bash loop (#213)
-    awk -v p="${input_path}" 'BEGIN {
-        n = split(p, a, ":")
-        for (i = 1; i <= n; i++)
-            if (a[i] != "" && !seen[a[i]]++) out = (out ? out ":" : "") a[i]
-        print out
-    }'
+    # O(n) deduplication via bash 4+ associative array — zero external forks (#216)
+    local -A seen
+    local -a result
+    local dir
+    IFS=':' read -ra dirs <<< "${input_path}"
+    for dir in "${dirs[@]}"; do
+        [[ -z "${dir}" ]] && continue
+        if [[ -z "${seen["${dir}"]+x}" ]]; then
+            seen["${dir}"]=1
+            result+=("${dir}")
+        fi
+    done
+    local IFS=':'
+    echo "${result[*]}"
 }
 
 # Require parser functions
@@ -163,7 +170,7 @@ oradba_add_oracle_path() {
         RDBMS|rdbms|GRID|grid)     product_type="database"  ;;
         DATABASE|database)         product_type="database"  ;;
         WLS|wls|WEBLOGIC|weblogic) product_type="weblogic"  ;;
-        *)                         product_type=$(printf '%s' "${product_type}" | tr '[:upper:]' '[:lower:]') ;;
+        *)                         product_type="${product_type,,}" ;;
     esac
 
     # Use v2 wrapper for isolated plugin execution (Phase 3)
@@ -235,7 +242,7 @@ oradba_set_lib_path() {
         RDBMS|rdbms|GRID|grid)     product_type="database"  ;;
         DATABASE|database)         product_type="database"  ;;
         WLS|wls|WEBLOGIC|weblogic) product_type="weblogic"  ;;
-        *)                         product_type=$(printf '%s' "${product_type}" | tr '[:upper:]' '[:lower:]') ;;
+        *)                         product_type="${product_type,,}" ;;
     esac
 
     # Use v2 wrapper for isolated plugin execution (Phase 3)
@@ -556,7 +563,7 @@ oradba_resolve_client_home() {
             
             # Convert type to uppercase for comparison
             local ptype_upper
-            ptype_upper=$(printf '%s' "${ptype}" | tr '[:lower:]' '[:upper:]')
+            ptype_upper="${ptype^^}"
             
             # Check if it's a client type or database (databases have client tools)
             if [[ "${ptype_upper}" == "CLIENT" ]] || [[ "${ptype_upper}" == "ICLIENT" ]] || [[ "${ptype_upper}" == "DATABASE" ]]; then
@@ -577,7 +584,7 @@ oradba_resolve_client_home() {
             
             # Convert type to uppercase for comparison
             local ptype_upper
-            ptype_upper=$(printf '%s' "${ptype}" | tr '[:lower:]' '[:upper:]')
+            ptype_upper="${ptype^^}"
             
             # Match by name or alias
             if [[ "${name}" == "${setting}" ]] || [[ "${alias}" == "${setting}" ]]; then
@@ -742,7 +749,7 @@ oradba_resolve_java_home() {
             
             # Convert type to uppercase for comparison
             local ptype_upper
-            ptype_upper=$(printf '%s' "${ptype}" | tr '[:lower:]' '[:upper:]')
+            ptype_upper="${ptype^^}"
             
             # Check if it's a Java type
             if [[ "${ptype_upper}" == "JAVA" ]]; then
@@ -773,7 +780,7 @@ oradba_resolve_java_home() {
             
             # Convert type to uppercase for comparison
             local ptype_upper
-            ptype_upper=$(printf '%s' "${ptype}" | tr '[:lower:]' '[:upper:]')
+            ptype_upper="${ptype^^}"
             
             # Match by name or alias
             if [[ "${name}" == "${setting}" ]] || [[ "${alias}" == "${setting}" ]]; then

--- a/src/lib/oradba_env_builder.sh
+++ b/src/lib/oradba_env_builder.sh
@@ -37,10 +37,10 @@ declare ORADBA_BUILDER_LOGGER="${ORADBA_BUILDER_LOGGER:-}"
 # ------------------------------------------------------------------------------
 oradba_builder_init() {
     local logger="${1:-}"
-    
+
     # Store logger function reference
     ORADBA_BUILDER_LOGGER="$logger"
-    
+
     return 0
 }
 
@@ -59,13 +59,13 @@ _oradba_builder_log() {
         "$ORADBA_BUILDER_LOGGER" "$@"
         return 0
     fi
-    
+
     # Priority 2: Fall back to oradba_log if available (backward compatibility)
-    if declare -f oradba_log &>/dev/null; then
+    if declare -f oradba_log &> /dev/null; then
         oradba_log "$@"
         return 0
     fi
-    
+
     # Priority 3: No-op (silent)
     return 0
 }
@@ -132,20 +132,20 @@ fi
 oradba_clean_path() {
     local new_path=""
     local IFS=":"
-    
+
     for dir in $PATH; do
         # Skip Oracle directories
         [[ "$dir" =~ /oracle/ ]] && continue
         [[ "$dir" =~ /grid/ ]] && continue
         [[ "$dir" =~ instantclient ]] && continue
-        
+
         # Add to new path
         if [[ -n "$new_path" ]]; then
             new_path="${new_path}:"
         fi
         new_path="${new_path}${dir}"
     done
-    
+
     export PATH="$new_path"
 }
 
@@ -162,15 +162,15 @@ oradba_add_oracle_path() {
     local oracle_home="$1"
     local product_type="${2:-database}"
     local new_path=""
-    
+
     [[ ! -d "$oracle_home" ]] && return 1
 
     # Convert product type to lowercase for plugin matching (case lookup, no subshell)
     case "${product_type}" in
-        RDBMS|rdbms|GRID|grid)     product_type="database"  ;;
-        DATABASE|database)         product_type="database"  ;;
-        WLS|wls|WEBLOGIC|weblogic) product_type="weblogic"  ;;
-        *)                         product_type="${product_type,,}" ;;
+        RDBMS | rdbms | GRID | grid) product_type="database" ;;
+        DATABASE | database) product_type="database" ;;
+        WLS | wls | WEBLOGIC | weblogic) product_type="weblogic" ;;
+        *) product_type="${product_type,,}" ;;
     esac
 
     # Use v2 wrapper for isolated plugin execution (Phase 3)
@@ -180,7 +180,7 @@ oradba_add_oracle_path() {
         _oradba_builder_log DEBUG "Plugin ${product_type}: plugin_build_bin_path failed or N/A, using fallback"
         new_path=""
     fi
-    
+
     # Fallback if plugin not found or failed
     if [[ -z "$new_path" ]]; then
         _oradba_builder_log DEBUG "Using fallback PATH for ${product_type}"
@@ -191,13 +191,13 @@ oradba_add_oracle_path() {
             new_path="$oracle_home"
         fi
     fi
-    
+
     # Add paths to PATH only if directories exist AND not already in PATH
     # Handle both single paths and colon-separated path lists
     if [[ -n "$new_path" ]]; then
         [[ "${ORADBA_DEBUG:-false}" == "true" ]] && echo "DEBUG: oradba_add_oracle_path - new_path: $new_path" >&2
         [[ "${ORADBA_DEBUG:-false}" == "true" ]] && echo "DEBUG: oradba_add_oracle_path - Current PATH before: $PATH" >&2
-        
+
         IFS=':' read -ra path_array <<< "$new_path"
         for dir in "${path_array[@]}"; do
             # Only add if directory exists and not already in PATH
@@ -208,7 +208,7 @@ oradba_add_oracle_path() {
                 [[ "${ORADBA_DEBUG:-false}" == "true" ]] && echo "DEBUG: oradba_add_oracle_path - Skipping: $dir" >&2
             fi
         done
-        
+
         [[ "${ORADBA_DEBUG:-false}" == "true" ]] && echo "DEBUG: oradba_add_oracle_path - Current PATH after: $PATH" >&2
     fi
 }
@@ -227,22 +227,22 @@ oradba_set_lib_path() {
     local product_type="${2:-database}"
     local lib_path=""
     local lib_var="LD_LIBRARY_PATH"
-    
+
     [[ ! -d "$oracle_home" ]] && return 1
-    
+
     # Determine platform library variable
     case "$(uname -s)" in
-        HP-UX)  lib_var="SHLIB_PATH" ;;
-        AIX)    lib_var="LIBPATH" ;;
+        HP-UX) lib_var="SHLIB_PATH" ;;
+        AIX) lib_var="LIBPATH" ;;
         Darwin) lib_var="DYLD_LIBRARY_PATH" ;;
     esac
-    
+
     # Convert product type to lowercase for plugin matching (case lookup, no subshell)
     case "${product_type}" in
-        RDBMS|rdbms|GRID|grid)     product_type="database"  ;;
-        DATABASE|database)         product_type="database"  ;;
-        WLS|wls|WEBLOGIC|weblogic) product_type="weblogic"  ;;
-        *)                         product_type="${product_type,,}" ;;
+        RDBMS | rdbms | GRID | grid) product_type="database" ;;
+        DATABASE | database) product_type="database" ;;
+        WLS | wls | WEBLOGIC | weblogic) product_type="weblogic" ;;
+        *) product_type="${product_type,,}" ;;
     esac
 
     # Use v2 wrapper for isolated plugin execution (Phase 3)
@@ -252,7 +252,7 @@ oradba_set_lib_path() {
         _oradba_builder_log DEBUG "Plugin ${product_type}: plugin_build_lib_path failed or N/A, using fallback"
         lib_path=""
     fi
-    
+
     # Fallback if plugin not found or failed
     if [[ -z "$lib_path" ]]; then
         _oradba_builder_log DEBUG "Using fallback LIB_PATH for ${product_type}"
@@ -267,7 +267,7 @@ oradba_set_lib_path() {
             lib_path="${oracle_home}"
         fi
     fi
-    
+
     # Clean existing Oracle library paths from the environment
     eval "local existing=\"\${${lib_var}}\""
     if [[ -n "$existing" ]]; then
@@ -280,23 +280,23 @@ oradba_set_lib_path() {
                 _oradba_builder_log DEBUG "Removing old Oracle path: ${dir}"
                 continue
             fi
-            
+
             # Add to cleaned path
             cleaned_path="${cleaned_path:+${cleaned_path}:}${dir}"
         done
         _oradba_builder_log DEBUG "Cleaned ${lib_var}: ${cleaned_path}"
-        
+
         # Append cleaned non-Oracle paths to new Oracle paths
         if [[ -n "$cleaned_path" ]]; then
             lib_path="${lib_path:+${lib_path}:}${cleaned_path}"
         fi
     fi
-    
+
     # Deduplicate library path
     lib_path="$(oradba_dedupe_path "$lib_path")"
-    
+
     _oradba_builder_log DEBUG "Final ${lib_var} to be exported: ${lib_path}"
-    
+
     # Export library path variable (always export, even if empty)
     # This ensures we clear old values from previous environments
     export ${lib_var}="$lib_path"
@@ -313,9 +313,9 @@ oradba_detect_rooh() {
     local oracle_home="$1"
     local oracle_base=""
     local is_rooh=0
-    
+
     [[ ! -d "$oracle_home" ]] && return 1
-    
+
     # Check for orabasetab file (12.2+)
     if [[ -f "${oracle_home}/install/orabasetab" ]]; then
         # Format: ORACLE_HOME:ORACLE_BASE:ORACLE_HOME_NAME:Y/N
@@ -330,24 +330,24 @@ oradba_detect_rooh() {
             fi
         done < "${oracle_home}/install/orabasetab"
     fi
-    
+
     # If ORACLE_BASE not found in orabasetab, derive it
     if [[ -z "$oracle_base" ]]; then
         # Standard: /u01/app/oracle/product/... → /u01/app/oracle
         oracle_base=$(dirname "$(dirname "$oracle_home")")
     fi
-    
+
     # Export variables
     export ORACLE_BASE="${oracle_base}"
     export ORADBA_ROOH="${is_rooh}"
-    
+
     # Set dbs directory based on ROOH
     if [[ $is_rooh -eq 1 ]]; then
         export ORADBA_DBS="${oracle_base}/dbs"
     else
         export ORADBA_DBS="${oracle_home}/dbs"
     fi
-    
+
     return $is_rooh
 }
 
@@ -375,15 +375,15 @@ oradba_set_oracle_vars() {
     local oracle_sid="$1"
     local oracle_home="$2"
     local product_type="$3"
-    
+
     [[ -z "$oracle_sid" ]] && return 1
     [[ -z "$oracle_home" ]] && return 1
     [[ ! -d "$oracle_home" ]] && return 1
-    
+
     # Apply product-specific adjustments via plugin system
     local datasafe_parent=""
     local adjusted_home="${oracle_home}"
-    
+
     if [[ "$product_type" == "DATASAFE" ]]; then
         # Use v2 wrapper for isolated plugin execution (Phase 3)
         if execute_plugin_function_v2 "datasafe" "adjust_environment" "${oracle_home}" "adjusted_home"; then
@@ -394,26 +394,26 @@ oradba_set_oracle_vars() {
             adjusted_home="${oracle_home}/oracle_cman_home"
         fi
     fi
-    
+
     oracle_home="${adjusted_home}"
-    
+
     # Core Oracle variables
     export ORACLE_SID="$oracle_sid"
     export ORACLE_HOME="$oracle_home"
-    
+
     # Export DataSafe parent directory if applicable
     if [[ -n "$datasafe_parent" ]]; then
         export DATASAFE_INSTALL_DIR="$datasafe_parent"
     fi
-    
+
     # Detect and set ORACLE_BASE
     oradba_detect_rooh "$oracle_home"
-    
+
     # Set ORACLE_UNQNAME (for databases)
     if [[ "$product_type" == "RDBMS" ]]; then
         export ORACLE_UNQNAME="${ORACLE_UNQNAME:-${oracle_sid}}"
     fi
-    
+
     # Set TNS_ADMIN
     if [[ "$product_type" == "RDBMS" ]] || [[ "$product_type" == "CLIENT" ]]; then
         if [[ -d "${oracle_home}/network/admin" ]]; then
@@ -431,16 +431,16 @@ oradba_set_oracle_vars() {
         # Instant Client: TNS_ADMIN usually in separate location
         export TNS_ADMIN="${TNS_ADMIN:-${ORADBA_BASE}/network/admin}"
     fi
-    
+
     # Set NLS variables
     export NLS_LANG="${NLS_LANG:-AMERICAN_AMERICA.AL32UTF8}"
     export NLS_DATE_FORMAT="${NLS_DATE_FORMAT:-YYYY-MM-DD HH24:MI:SS}"
-    
+
     # Set ORA_NLS10 for older versions (optional)
     if [[ -d "${oracle_home}/nls/data" ]]; then
         export ORA_NLS10="${oracle_home}/nls/data"
     fi
-    
+
     return 0
 }
 
@@ -453,12 +453,12 @@ oradba_set_oracle_vars() {
 oradba_set_asm_environment() {
     # ASM uses sysasm privilege instead of sysdba
     export ORACLE_SYSASM="TRUE"
-    
+
     # Set GRID_HOME if not already set
     if [[ -z "$GRID_HOME" ]]; then
         export GRID_HOME="$ORACLE_HOME"
     fi
-    
+
     return 0
 }
 
@@ -470,23 +470,23 @@ oradba_set_asm_environment() {
 # ------------------------------------------------------------------------------
 oradba_set_product_environment() {
     local product_type="$1"
-    
+
     case "$product_type" in
         GRID)
             export GRID_HOME="${ORACLE_HOME}"
             ;;
-            
+
         DATASAFE)
             # DATASAFE_HOME points to connector home (same as ORACLE_HOME)
             export DATASAFE_HOME="${ORACLE_HOME}"
-            
+
             # DATASAFE_INSTALL_DIR already set in oradba_set_oracle_vars if applicable
-            
+
             if [[ -d "${ORACLE_HOME}/config" ]]; then
                 export DATASAFE_CONFIG="${ORACLE_HOME}/config"
             fi
             ;;
-            
+
         OUD)
             # OUD instance home
             if [[ -d "${ORACLE_HOME}/instances/${ORACLE_SID}" ]]; then
@@ -494,7 +494,7 @@ oradba_set_product_environment() {
                 export OUD_INSTANCE_CONFIG="${OUD_INSTANCE_HOME}/OUD/config"
             fi
             ;;
-            
+
         WLS)
             # WebLogic Server variables
             export WLS_HOME="${ORACLE_HOME}/wlserver"
@@ -503,7 +503,7 @@ oradba_set_product_environment() {
             fi
             ;;
     esac
-    
+
     return 0
 }
 
@@ -515,10 +515,10 @@ oradba_set_product_environment() {
 # ------------------------------------------------------------------------------
 oradba_product_needs_client() {
     local product_type="$1"
-    
+
     # Products without their own Oracle client tools
     case "${product_type}" in
-        DATASAFE|OUD|WLS|WEBLOGIC|OMS|EMAGENT)
+        DATASAFE | OUD | WLS | WEBLOGIC | OMS | EMAGENT)
             return 0
             ;;
         *)
@@ -540,19 +540,19 @@ oradba_resolve_client_home() {
     local setting="${ORADBA_CLIENT_PATH_FOR_NON_CLIENT:-none}"
     local homes_file
     local client_home=""
-    
+
     # Handle "none" - no client needed
     [[ "${setting}" == "none" ]] && return 1
-    
+
     # Get oracle homes config file
     if [[ -f "${ORADBA_BASE}/lib/oradba_common.sh" ]]; then
-        homes_file=$(get_oracle_homes_path 2>/dev/null) || homes_file=""
+        homes_file=$(get_oracle_homes_path 2> /dev/null) || homes_file=""
     else
         homes_file="${ORADBA_BASE}/etc/oradba_homes.conf"
     fi
-    
+
     [[ ! -f "${homes_file}" ]] && return 1
-    
+
     # Handle "auto" - find first CLIENT or ICLIENT
     if [[ "${setting}" == "auto" ]]; then
         # Format: NAME:PATH:TYPE:ORDER:ALIAS:DESCRIPTION:VERSION
@@ -560,11 +560,11 @@ oradba_resolve_client_home() {
             # Skip empty lines and comments
             [[ -z "${name}" ]] && continue
             [[ "${name}" =~ ^[[:space:]]*# ]] && continue
-            
+
             # Convert type to uppercase for comparison
             local ptype_upper
             ptype_upper="${ptype^^}"
-            
+
             # Check if it's a client type or database (databases have client tools)
             if [[ "${ptype_upper}" == "CLIENT" ]] || [[ "${ptype_upper}" == "ICLIENT" ]] || [[ "${ptype_upper}" == "DATABASE" ]]; then
                 # Validate directory exists
@@ -581,11 +581,11 @@ oradba_resolve_client_home() {
             # Skip empty lines and comments
             [[ -z "${name}" ]] && continue
             [[ "${name}" =~ ^[[:space:]]*# ]] && continue
-            
+
             # Convert type to uppercase for comparison
             local ptype_upper
             ptype_upper="${ptype^^}"
-            
+
             # Match by name or alias
             if [[ "${name}" == "${setting}" ]] || [[ "${alias}" == "${setting}" ]]; then
                 # Validate it has client tools (database, client, or instant client)
@@ -599,13 +599,13 @@ oradba_resolve_client_home() {
             fi
         done < <(grep -v "^#\|^$" "${homes_file}")
     fi
-    
+
     # Return result
     if [[ -n "${client_home}" ]] && [[ -d "${client_home}" ]]; then
         echo "${client_home}"
         return 0
     fi
-    
+
     return 1
 }
 
@@ -620,21 +620,21 @@ oradba_add_client_path() {
     local product_type="$1"
     local client_home=""
     local client_bin=""
-    
+
     # Check if product needs client tools
     if ! oradba_product_needs_client "${product_type}"; then
         _oradba_builder_log DEBUG "Product ${product_type} has built-in client, skipping client path"
         return 0
     fi
-    
+
     # Resolve client home
     client_home=$(oradba_resolve_client_home) || {
         _oradba_builder_log DEBUG "No client home configured or found for ${product_type}"
         return 0
     }
-    
+
     _oradba_builder_log DEBUG "Resolved client home: ${client_home}"
-    
+
     # Determine bin directory based on client type
     # Check if it's instant client (no bin subdirectory)
     # Use a loop to check for libclntsh.so* files (avoid SC2144)
@@ -647,7 +647,7 @@ oradba_add_client_path() {
             fi
         done
     fi
-    
+
     if [[ $is_iclient -eq 1 ]]; then
         # Instant client - add home directly
         client_bin="${client_home}"
@@ -655,27 +655,27 @@ oradba_add_client_path() {
         # Regular client - add bin subdirectory
         client_bin="${client_home}/bin"
     fi
-    
+
     # Validate bin directory exists
     if [[ ! -d "${client_bin}" ]]; then
         _oradba_builder_log WARN "Client bin directory not found: ${client_bin}"
         return 1
     fi
-    
+
     # Export ORACLE_CLIENT_HOME
     export ORACLE_CLIENT_HOME="${client_home}"
     _oradba_builder_log DEBUG "Exported ORACLE_CLIENT_HOME=${ORACLE_CLIENT_HOME}"
-    
+
     # Check if already in PATH
     if [[ ":${PATH}:" == *":${client_bin}:"* ]]; then
         _oradba_builder_log DEBUG "Client path already in PATH: ${client_bin}"
         return 0
     fi
-    
+
     # Append to PATH (after current entries)
     export PATH="${PATH}:${client_bin}"
     _oradba_builder_log DEBUG "Added client path for ${product_type}: ${client_bin}"
-    
+
     return 0
 }
 
@@ -687,11 +687,11 @@ oradba_add_client_path() {
 # ------------------------------------------------------------------------------
 oradba_product_needs_java() {
     local product_type="$1"
-    
+
     # Products that typically need Java but may not ship it
     # (or users want to override the shipped Java)
     case "${product_type}" in
-        DATASAFE|OUD|WLS|WEBLOGIC|OMS|EMAGENT)
+        DATASAFE | OUD | WLS | WEBLOGIC | OMS | EMAGENT)
             return 0
             ;;
         *)
@@ -715,10 +715,10 @@ oradba_resolve_java_home() {
     local setting="${ORADBA_JAVA_PATH_FOR_NON_JAVA:-none}"
     local homes_file
     local java_home=""
-    
+
     # Handle "none" - no Java needed
     [[ "${setting}" == "none" ]] && return 1
-    
+
     # Handle "auto" - find Java automatically
     if [[ "${setting}" == "auto" ]]; then
         # First, check $ORACLE_HOME/java if ORACLE_HOME is set
@@ -730,27 +730,27 @@ oradba_resolve_java_home() {
                 return 0
             fi
         fi
-        
+
         # Get oracle homes config file
         if [[ -f "${ORADBA_BASE}/lib/oradba_common.sh" ]]; then
-            homes_file=$(get_oracle_homes_path 2>/dev/null) || homes_file=""
+            homes_file=$(get_oracle_homes_path 2> /dev/null) || homes_file=""
         else
             homes_file="${ORADBA_BASE}/etc/oradba_homes.conf"
         fi
-        
+
         [[ ! -f "${homes_file}" ]] && return 1
-        
+
         # Find first JAVA type in oradba_homes.conf
         # Format: NAME:PATH:TYPE:ORDER:ALIAS:DESCRIPTION:VERSION
         while IFS=':' read -r name path ptype _order alias _desc _version; do
             # Skip empty lines and comments
             [[ -z "${name}" ]] && continue
             [[ "${name}" =~ ^[[:space:]]*# ]] && continue
-            
+
             # Convert type to uppercase for comparison
             local ptype_upper
             ptype_upper="${ptype^^}"
-            
+
             # Check if it's a Java type
             if [[ "${ptype_upper}" == "JAVA" ]]; then
                 # Validate directory exists and has java binary
@@ -765,23 +765,23 @@ oradba_resolve_java_home() {
         # Handle specific Java name (could be name or alias)
         # Get oracle homes config file
         if [[ -f "${ORADBA_BASE}/lib/oradba_common.sh" ]]; then
-            homes_file=$(get_oracle_homes_path 2>/dev/null) || homes_file=""
+            homes_file=$(get_oracle_homes_path 2> /dev/null) || homes_file=""
         else
             homes_file="${ORADBA_BASE}/etc/oradba_homes.conf"
         fi
-        
+
         [[ ! -f "${homes_file}" ]] && return 1
-        
+
         # Format: NAME:PATH:TYPE:ORDER:ALIAS:DESCRIPTION:VERSION
         while IFS=':' read -r name path ptype _order alias _desc _version; do
             # Skip empty lines and comments
             [[ -z "${name}" ]] && continue
             [[ "${name}" =~ ^[[:space:]]*# ]] && continue
-            
+
             # Convert type to uppercase for comparison
             local ptype_upper
             ptype_upper="${ptype^^}"
-            
+
             # Match by name or alias
             if [[ "${name}" == "${setting}" ]] || [[ "${alias}" == "${setting}" ]]; then
                 # Validate it's a Java type
@@ -796,13 +796,13 @@ oradba_resolve_java_home() {
             fi
         done < <(grep -v "^#\|^$" "${homes_file}")
     fi
-    
+
     # Return result
     if [[ -n "${java_home}" ]] && [[ -d "${java_home}" ]]; then
         echo "${java_home}"
         return 0
     fi
-    
+
     return 1
 }
 
@@ -820,7 +820,7 @@ oradba_add_java_path() {
     local current_oracle_home="${2:-}"
     local java_home=""
     local java_bin=""
-    
+
     # Check if product needs Java or if user wants to override
     # If ORADBA_JAVA_PATH_FOR_NON_JAVA is set to anything other than "none",
     # we honor it regardless of product type (allows override for DATABASE/CLIENT)
@@ -832,15 +832,15 @@ oradba_add_java_path() {
             return 0
         fi
     fi
-    
+
     # Resolve Java home
     java_home=$(oradba_resolve_java_home "${current_oracle_home}") || {
         _oradba_builder_log DEBUG "No Java home configured or found for ${product_type}"
         return 0
     }
-    
+
     _oradba_builder_log DEBUG "Resolved Java home: ${java_home}"
-    
+
     # Set Java bin directory
     if [[ -d "${java_home}/bin" ]]; then
         java_bin="${java_home}/bin"
@@ -848,21 +848,21 @@ oradba_add_java_path() {
         _oradba_builder_log WARN "Java bin directory not found: ${java_home}/bin"
         return 1
     fi
-    
+
     # Export JAVA_HOME
     export JAVA_HOME="${java_home}"
     _oradba_builder_log DEBUG "Exported JAVA_HOME=${JAVA_HOME}"
-    
+
     # Check if already in PATH
     if [[ ":${PATH}:" == *":${java_bin}:"* ]]; then
         _oradba_builder_log DEBUG "Java path already in PATH: ${java_bin}"
         return 0
     fi
-    
+
     # Prepend to PATH (before current entries so it takes precedence)
     export PATH="${java_bin}:${PATH}"
     _oradba_builder_log DEBUG "Added Java path for ${product_type}: ${java_bin}"
-    
+
     return 0
 }
 
@@ -889,7 +889,7 @@ oradba_build_environment() {
 
         # Get metadata from oradba_homes.conf (single lookup for all fields)
         local _path_entry
-        _path_entry=$(oradba_find_home "$oracle_home" 2>/dev/null || true)
+        _path_entry=$(oradba_find_home "$oracle_home" 2> /dev/null || true)
         if [[ -n "$_path_entry" ]]; then
             local _pname _ppath _ptype _porder _palias
             IFS='|' read -r _pname _ppath _ptype _porder _palias _ _ <<< "$_path_entry"
@@ -901,7 +901,7 @@ oradba_build_environment() {
         [[ -z "$product_type" ]] && product_type=$(oradba_get_product_type "$oracle_home")
 
         # Set SID to alias name (for non-empty oracle_sid requirement in oradba_set_oracle_vars)
-        oracle_sid=$(oradba_get_home_metadata "$oracle_home" "Dummy_SID" 2>/dev/null || true)
+        oracle_sid=$(oradba_get_home_metadata "$oracle_home" "Dummy_SID" 2> /dev/null || true)
         oracle_sid="${oracle_sid:-${home_alias:-dummy}}"
 
     else
@@ -926,9 +926,9 @@ oradba_build_environment() {
             fi
         else
             # Not found in oratab — try oradba_homes.conf (Oracle Home names/aliases)
-            if command -v oradba_find_home &>/dev/null; then
+            if command -v oradba_find_home &> /dev/null; then
                 local home_entry
-                home_entry=$(oradba_find_home "$oracle_sid" 2>/dev/null)
+                home_entry=$(oradba_find_home "$oracle_sid" 2> /dev/null)
                 if [[ -n "$home_entry" ]]; then
                     # Format: NAME|PATH|TYPE|ORDER|ALIAS|DESCRIPTION|VERSION
                     local _hname _hpath _htype _horder _halias
@@ -948,48 +948,48 @@ oradba_build_environment() {
     # Validate we have required info
     [[ -z "$oracle_home" ]] && return 1
     [[ ! -d "$oracle_home" ]] && return 1
-    
+
     # Clean existing Oracle paths
     oradba_clean_path
-    
+
     # Set core Oracle variables
     oradba_set_oracle_vars "$oracle_sid" "$oracle_home" "$product_type" || return 1
-    
+
     # Set PATH
     oradba_add_oracle_path "$oracle_home" "$product_type"
-    
+
     # Set library path
     oradba_set_lib_path "$oracle_home" "$product_type"
-    
+
     # Set product-specific environment
     oradba_set_product_environment "$product_type"
-    
+
     # Special handling for ASM
     if oradba_is_asm_instance "$oracle_sid"; then
         oradba_set_asm_environment
     fi
-    
+
     # Apply configuration files (Phase 2)
-    if command -v oradba_apply_product_config &>/dev/null; then
+    if command -v oradba_apply_product_config &> /dev/null; then
         oradba_apply_product_config "$product_type" "$oracle_sid"
     fi
-    
+
     # Add Java path for products that need it (e.g., DataSafe, OUD, WebLogic)
     # This happens BEFORE client path so Java takes precedence (prepended to PATH)
     # Pass oracle_home for auto-detection of $ORACLE_HOME/java
     oradba_add_java_path "$product_type" "$oracle_home"
-    
+
     # Add client path for non-client products (e.g., DataSafe, OUD, WebLogic)
     # This happens after product PATH setup and config files, but before deduplication
     oradba_add_client_path "$product_type"
-    
+
     # Final PATH deduplication after all configs loaded
     # This ensures custom PATH additions from config files are deduplicated
     # Must happen AFTER config files to catch any PATH modifications they make
     local final_path final_lib_path
     final_path="$(oradba_dedupe_path "$PATH")"
     export PATH="$final_path"
-    
+
     # Also deduplicate library paths if they exist
     if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
         final_lib_path="$(oradba_dedupe_path "$LD_LIBRARY_PATH")"
@@ -1007,14 +1007,14 @@ oradba_build_environment() {
         final_lib_path="$(oradba_dedupe_path "$DYLD_LIBRARY_PATH")"
         export DYLD_LIBRARY_PATH="$final_lib_path"
     fi
-    
+
     # Load extensions after Oracle environment is fully set up
     # Extensions are loaded based on priority (mixed with Oracle paths)
     # Default priority: 50 (loaded after Oracle paths)
-    if command -v load_extensions >/dev/null 2>&1; then
+    if command -v load_extensions > /dev/null 2>&1; then
         load_extensions
     fi
-    
+
     # Set tracking variables
     export ORADBA_ENV_LOADED=1
     export ORADBA_CURRENT_SID="$oracle_sid"

--- a/src/lib/oradba_env_builder.sh
+++ b/src/lib/oradba_env_builder.sh
@@ -927,10 +927,23 @@ oradba_build_environment() {
                 product_type=$(oradba_get_product_type "$oracle_home")
             fi
         else
-            return 1
+            # Not found in oratab — try oradba_homes.conf (Oracle Home names/aliases)
+            if command -v oradba_find_home &>/dev/null; then
+                local home_entry
+                home_entry=$(oradba_find_home "$oracle_sid" 2>/dev/null)
+                if [[ -n "$home_entry" ]]; then
+                    # Format: NAME|PATH|TYPE|ORDER|ALIAS|DESCRIPTION|VERSION
+                    local _hname _hpath _htype
+                    IFS='|' read -r _hname _hpath _htype _ _ _ _ <<< "$home_entry"
+                    oracle_home="$_hpath"
+                    oracle_sid=""
+                    [[ -n "$_htype" && -z "$product_type" ]] && product_type="$_htype"
+                fi
+            fi
+            [[ -z "$oracle_home" ]] && return 1
         fi
     fi
-    
+
     # Validate we have required info
     [[ -z "$oracle_home" ]] && return 1
     [[ ! -d "$oracle_home" ]] && return 1


### PR DESCRIPTION
## Summary

Two startup bottleneck fixes on top of the `oradba_dedupe_path` O(n²)→awk fix already
committed in `6a6d0cc` (#213).

## Changes

### Commit 1 — `parse_extension_metadata` + `load_extension` provides block (#214)

**`parse_extension_metadata()`:** replaced `grep|head|cut|sed` pipeline (4 forks/call,
called 5+ times/extension) with a pure-bash `while IFS= read -r` loop reading the file
directly. `read -r value <<< "${line#key:}"` strips key prefix and trims whitespace via
default IFS. Comment lines (`# ...`) are skipped.

**`load_extension()` provides block:** replaced 3 `grep -A5|grep|awk|head` pipeline chains
plus 2 `parse_extension_metadata` calls (11+ forks from a ~20-line file) with a single-pass
`while/read` state machine. Indented lines go to the `provides:` block, top-level keys reset
state. Comments and blank lines skipped. Zero subshells.

### Commit 2 — `tr` subshells + `oradba_dedupe_path` awk (#216)

**`oradba_dedupe_path()`:** replaced the `awk` invocation (1 fork, already O(n)) with a
`declare -A` associative-array lookup — O(n), zero external forks, pure bash 4+.

**Case conversion:** replaced all 9 `$(printf '%s' "$var" | tr '[:lower:]' '[:upper:]')`
and `tr '[:upper:]' '[:lower:]')` subshells with `${var^^}` / `${var,,}` bash 4+ parameter
expansion — zero forks each:
- `oradba_env_builder.sh`: 6 occurrences (lines 166, 238, 559, 580, 745, 776)
- `extensions.sh`: 3 occurrences (lines 162, 163, 595)

## Profiling (macOS, measured live)

| Phase | Baseline | After #214 | After #216 | Total delta |
|---|---|---|---|---|
| `oradba_build_environment` | ~3.3 s | ~1.9 s | ~1.7 s | **-1.6 s** |
| `load_extensions` | ~1.5 s | ~1.0 s | ~0.6 s | **-0.9 s** |
| **Total `oraenv`** | **~7.5 s** | **~5.6 s** | **~4.2 s** | **-3.3 s (-44%)** |

## Test plan

- [x] `bats tests/test_oradba_env_builder_unit.bats` — 39/39 pass (dedupe, clean_path, build_environment)
- [x] `bats tests/test_extensions.bats` — 100/100 pass (parse_extension_metadata, load_extension, get_extension_property)
- [x] Live profiling on macOS confirms cumulative improvement

Closes #214
Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)